### PR TITLE
fix: Wrong executing file

### DIFF
--- a/make
+++ b/make
@@ -2,4 +2,4 @@
 
 g++ -o compiled.o main.cpp -lncurses -std=c++1y -Wall 
 #-Weffc++ -Winit-self 
-./a.out
+./compiled.out


### PR DESCRIPTION
The executing file was ./a.out, but in the command above the executing file is named compiled.o. Thus, I adjusted the script with the right executing file.